### PR TITLE
Refactor Optoma client: fix bugs, reduce duplication, modernize

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-pip insall asyncoptoma
+pip install asyncoptoma
 ```
 
 ## Usage

--- a/asyncoptoma/__init__.py
+++ b/asyncoptoma/__init__.py
@@ -1,540 +1,438 @@
+from __future__ import annotations
+
 import hashlib
+import logging
+from typing import Any
 
 import httpx
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
+
+_LOGGER = logging.getLogger(__name__)
+
+_CONTROL_PATH = "/tgi/control.tgi"
+_LOGIN_PATH = "/tgi/login.tgi"
+
+_DROPDOWNS: tuple[str, ...] = (
+    "source",
+    "Degamma",
+    "Degamma2",
+    "colortmp",
+    "dismode0",
+    "dismode1",
+    "colorsp0",
+    "colorsp1",
+    "aspect0",
+    "aspect1",
+    "screen",
+    "projection",
+    "background",
+    "wall",
+    "logo",
+    "pwmode",
+    "lampmd",
+)
+
+_TOGGLES: tuple[str, ...] = (
+    "avmute",
+    "freeze",
+    "infohide",
+    "altitude",
+    "keypad",
+    "dismdlocked",
+    "directpwon",
+    "alwayson",
+)
+
+_INPUTS: tuple[str, ...] = (
+    "bright",
+    "contrast",
+    "Sharp",
+    "Phase",
+    "brill",
+    "zoom",
+    "hpos",
+    "vpos",
+    "autopw",
+    "sleep",
+    "projid",
+)
+
+_TOGGLE_COMMAND_LABELS: dict[str, str] = {
+    "avmute": "AV Mute",
+    "freeze": "Freeze",
+    "infohide": "Information Hide",
+    "altitude": "High Altitude",
+    "keypad": "Keypad Lock",
+    "dismdlocked": "Display Mode Lock",
+    "directpwon": "Direct Power On",
+    "alwayson": "Always On",
+}
 
 
 class Optoma:
-    def __init__(self, base_url: str, username: str = "admin", password: str = "admin"):
-        self.http = httpx.AsyncClient()
-        self.base_url = base_url
+    def __init__(
+        self,
+        base_url: str,
+        username: str = "admin",
+        password: str = "admin",
+        timeout: float = 10.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
         self.username = username
         self.password = password
-        self.status = {
-            "available_source": {},
-            "active_source": None,
-            "available_colortmp": {},
-            "active_colortmp": None,
-            "available_dismode0": {},
-            "active_dismode0": None,
-            "available_dismode1": {},
-            "active_dismode1": None,
-            "available_colorsp0": {},
-            "active_colorsp0": None,
-            "available_colorsp1": {},
-            "active_colorsp1": None,
-            "available_aspect0": {},
-            "active_aspect0": None,
-            "available_aspect1": {},
-            "active_aspect1": None,
-            "available_screen": {},
-            "active_screen": None,
-            "available_projection": {},
-            "active_projection": None,
-            "available_background": {},
-            "active_background": None,
-            "available_wall": {},
-            "active_wall": None,
-            "available_logo": {},
-            "active_logo": None,
-            "available_pwmode": {},
-            "active_pwmode": None,
-            "available_lampmd": {},
-            "active_lampmd": None,
-            "avmute": None,
-            "freeze": None,
-            "infohide": None,
-            "altitude": None,
-            "keypad": None,
-            "dismdlocked": None,
-            "directpwon": None,
-            "alwayson": None,
-            "bright": None,
-            "contrast": None,
-            "brill": None,
-            "zoom": None,
-            "hpos": None,
-            "vpos": None,
-            "autopw": None,
-            "sleep": None,
-            "projid": None,
+        self.http = httpx.AsyncClient(timeout=timeout)
+        self.status: dict[str, Any] = {
+            **{f"available_{name}": {} for name in _DROPDOWNS},
+            **{f"active_{name}": None for name in _DROPDOWNS},
+            **{name: None for name in _TOGGLES},
+            **{name: None for name in _INPUTS},
             "power": None,
         }
 
-    async def _make_request(self, method, path, data=None):
-        response = await self.http.request(method, f"{self.base_url}{path}", data=data)
-        return response
+    async def __aenter__(self) -> Optoma:
+        return self
 
-    async def login(self):
-        response = await self.http.get(f"{self.base_url}/login.htm")
+    async def __aexit__(self, *exc_info: object) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        await self.http.aclose()
+
+    async def _make_request(
+        self, method: str, path: str, data: dict[str, Any] | None = None
+    ) -> httpx.Response:
+        return await self.http.request(
+            method.upper(), f"{self.base_url}{path}", data=data
+        )
+
+    async def login(self) -> bool:
+        response = await self._make_request("GET", "/login.htm")
         soup = BeautifulSoup(response.text, "html.parser")
         challenge_element = soup.find("input", {"name": "Challenge"})
         if challenge_element is None:
             return False
 
         challenge = challenge_element["value"]
-        login_str = self.username + self.password + challenge
-        response = hashlib.md5(login_str.encode())
+        login_hash = hashlib.md5(
+            f"{self.username}{self.password}{challenge}".encode()
+        ).hexdigest()
         data = {
             "user": 0,
             "Username": "1",
             "Password": "",
             "Challenge": "",
-            "Response": response.hexdigest(),
+            "Response": login_hash,
         }
 
-        response = await self.http.post(f"{self.base_url}/tgi/login.tgi", data=data)
+        response = await self._make_request("POST", _LOGIN_PATH, data=data)
         if response.status_code != 200:
-            return
+            return False
 
         await self.update_status()
+        return True
 
-    def _parse_drop_down_options(self, select_element: BeautifulSoup):
-        option_elements = select_element.find_all("option")
-        options = []
-        selected = None
-        for option_element in option_elements:
-            label = option_element.get_text().replace("\n", " ")
-            options.append(
-                {"id": int(option_element["value"]), "label": label.replace(".", "")}
-            )
+    @staticmethod
+    def _parse_drop_down_options(
+        select_element: Tag,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        options: list[dict[str, Any]] = []
+        selected: str | None = None
+        for option_element in select_element.find_all("option"):
+            label = option_element.get_text().replace("\n", " ").replace(".", "").strip()
+            options.append({"id": int(option_element["value"]), "label": label})
             if option_element.has_attr("selected"):
                 selected = label
+        options.sort(key=lambda i: i["id"])
+        return options, selected
 
-        return sorted(options, key=lambda i: i["id"]), selected
-
-    async def update_status(self):
-        dropdowns = [
-            "source",
-            "Degamma",
-            "Degamma2",
-            "colortmp",
-            "dismode0",
-            "dismode1",
-            "colorsp0",
-            "colorsp1",
-            "aspect0",
-            "aspect1",
-            "screen",
-            "projection",
-            "background",
-            "wall",
-            "logo",
-            "pwmode",
-            "lampmd",
-        ]
-        toggle_buttons = [
-            "avmute_td",
-            "freeze_td",
-            "infohide_td",
-            "altitude_td",
-            "keypad_td",
-            "dismdlocked_td",
-            "directpwon_td",
-            "alwayson_td",
-        ]
-        inputs = [
-            "bright",
-            "contrast",
-            "Sharp" "Phase",
-            "brill",
-            "zoom",
-            "hpos",
-            "vpos",
-            "autopw",
-            "sleep",
-            "projid",
-        ]
-
+    async def update_status(self) -> None:
         response = await self._make_request("GET", "/control.htm")
         soup = BeautifulSoup(response.text, "html.parser")
 
+        dropdowns = set(_DROPDOWNS)
         for select in soup.find_all("select"):
-            if select.has_attr("id") and select["id"] in dropdowns:
+            key = select.get("id")
+            if key in dropdowns:
                 options, active = self._parse_drop_down_options(select)
-                for option in options:
-                    if f"available_{select['id']}" not in self.status:
-                        self.status[f"available_{select['id']}"] = {}
-                    self.status[f"available_{select['id']}"][option["label"]] = option[
-                        "id"
-                    ]
-                self.status[f"active_{select['id']}"] = active
+                self.status[f"available_{key}"] = {o["label"]: o["id"] for o in options}
+                self.status[f"active_{key}"] = active
 
+        toggles = set(_TOGGLES)
         for btn in soup.find_all("td"):
-            if btn.has_attr("id") and btn["id"] in toggle_buttons:
-                label = btn.get_text().replace("\n", "")
-                self.status[f"{btn['id'].replace('_td', '')}"] = (
-                    True if label == "On" or label == "Yes" else False
-                )
+            key = btn.get("id", "")
+            if key.endswith("_td"):
+                name = key[:-3]
+                if name in toggles:
+                    self.status[name] = btn.get_text().strip() in ("On", "Yes")
 
-        for input in soup.find_all("input"):
-            if input.has_attr("id") and input["id"] in inputs:
-                self.status[input["id"]] = int(input["value"])
+        inputs = set(_INPUTS)
+        for inp in soup.find_all("input"):
+            key = inp.get("id")
+            if key in inputs:
+                try:
+                    self.status[key] = int(inp["value"])
+                except (KeyError, ValueError):
+                    self.status[key] = None
 
-        power_on_button = soup.find("input", {"id": "pwr"})
-        self.status["power"] = True if int(power_on_button["value"]) == 1 else False
+        power = soup.find("input", {"id": "pwr"})
+        if power is not None and power.has_attr("value"):
+            try:
+                self.status["power"] = int(power["value"]) == 1
+            except ValueError:
+                self.status["power"] = None
 
-    async def get_available_sources(self):
+    async def _set_choice(self, field: str, value: str) -> None:
+        if self.status.get(f"active_{field}") == value:
+            return
+        available = self.status.get(f"available_{field}") or {}
+        if value not in available:
+            _LOGGER.warning("Value %r not available for %s", value, field)
+            return
+        await self._make_request("POST", _CONTROL_PATH, {field: available[value]})
+        self.status[f"active_{field}"] = value
+
+    async def _set_value(self, field: str, value: int) -> None:
+        await self._make_request("POST", _CONTROL_PATH, {field: value})
+        self.status[field] = value
+
+    async def _toggle(self, field: str, value: bool) -> None:
+        if self.status.get(field) == value:
+            return
+        await self._make_request(
+            "POST", _CONTROL_PATH, {field: _TOGGLE_COMMAND_LABELS[field]}
+        )
+        self.status[field] = value
+
+    # -- Sources --
+    async def get_available_sources(self) -> dict[str, int]:
         return self.status["available_source"]
 
-    async def get_active_source(self):
+    async def get_active_source(self) -> str | None:
         return self.status["active_source"]
 
-    async def set_active_source(self, value: str):
-        if self.status["active_source"] == value:
-            return
+    async def set_active_source(self, value: str) -> None:
+        await self._set_choice("source", value)
 
-        if value not in self.status["available_source"]:
-            return
-
-        command = {"source": self.status["available_source"][value]}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["active_source"] = value
-
-    async def get_available_dismodes_0(self):
+    # -- Display mode 0 --
+    async def get_available_dismodes_0(self) -> dict[str, int]:
         return self.status["available_dismode0"]
 
-    async def get_active_dismode_0(self):
+    async def get_active_dismode_0(self) -> str | None:
         return self.status["active_dismode0"]
 
-    async def set_active_dismode_0(self, value: str):
-        if self.status["active_dismode0"] == value:
-            return
+    async def set_active_dismode_0(self, value: str) -> None:
+        await self._set_choice("dismode0", value)
 
-        if value not in self.status["available_dismode0"]:
-            return
-
-        command = {"dismode0": self.status["available_dismode0"][value]}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["active_dismode0"] = value
-
-    async def get_available_dismodes_1(self):
+    # -- Display mode 1 --
+    async def get_available_dismodes_1(self) -> dict[str, int]:
         return self.status["available_dismode1"]
 
-    async def get_active_dismode_1(self):
+    async def get_active_dismode_1(self) -> str | None:
         return self.status["active_dismode1"]
 
-    async def set_active_dismode_1(self, value: str):
-        if self.status["active_dismode1"] == value:
-            return
+    async def set_active_dismode_1(self, value: str) -> None:
+        await self._set_choice("dismode1", value)
 
-        if value not in self.status["available_dismode1"]:
-            return
-
-        command = {"dismode1": self.status["available_dismode1"][value]}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["active_dismode1"] = value
-
-    async def get_available_colorsps_0(self):
+    # -- Color space 0 --
+    async def get_available_colorsps_0(self) -> dict[str, int]:
         return self.status["available_colorsp0"]
 
-    async def get_active_colorsp_0(self):
+    async def get_active_colorsp_0(self) -> str | None:
         return self.status["active_colorsp0"]
 
-    async def set_active_colorsp_0(self, value: str):
-        if self.status["active_colorsp0"] == value:
-            return
+    async def set_active_colorsp_0(self, value: str) -> None:
+        await self._set_choice("colorsp0", value)
 
-        if value not in self.status["available_colorsp0"]:
-            return
-
-        command = {"colorsp0": self.status["available_colorsp0"][value]}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["active_colorsp0"] = value
-
-    async def get_available_colorsps_1(self):
+    # -- Color space 1 --
+    async def get_available_colorsps_1(self) -> dict[str, int]:
         return self.status["available_colorsp1"]
 
-    async def get_active_colorsp_1(self):
+    async def get_active_colorsp_1(self) -> str | None:
         return self.status["active_colorsp1"]
 
-    async def set_active_colorsp_1(self, value: str):
-        if self.status["active_colorsp1"] == value:
-            return
+    async def set_active_colorsp_1(self, value: str) -> None:
+        await self._set_choice("colorsp1", value)
 
-        if value not in self.status["available_colorsp1"]:
-            return
-
-        command = {"colorsp1": self.status["available_colorsp1"][value]}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["active_colorsp1"] = value
-
-    async def get_available_gammas(self):
+    # -- Gamma --
+    async def get_available_gammas(self) -> dict[str, int]:
         return self.status["available_Degamma"]
 
-    async def get_active_gamma(self):
+    async def get_active_gamma(self) -> str | None:
         return self.status["active_Degamma"]
 
-    async def set_active_gamma(self, value: str):
-        if self.status["active_Degamma"] == value:
-            return
+    async def set_active_gamma(self, value: str) -> None:
+        await self._set_choice("Degamma", value)
 
-        if value not in self.status["available_Degamma"]:
-            return
-
-        command = {"Degamma": self.status["available_Degamma"][value]}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["active_Degamma"] = value
-
-    async def get_available_brightness_modes(self):
+    # -- Brightness / lamp mode --
+    async def get_available_brightness_modes(self) -> dict[str, int]:
         return self.status["available_lampmd"]
 
-    async def get_active_brightness_mode(self):
+    async def get_active_brightness_mode(self) -> str | None:
         return self.status["active_lampmd"]
 
-    async def set_active_brightness_mode(self, value: str):
-        if self.status["active_lampmd"] == value:
-            return
+    async def set_active_brightness_mode(self, value: str) -> None:
+        await self._set_choice("lampmd", value)
 
-        if value not in self.status["available_lampmd"]:
-            return
-
-        command = {"lampmd": self.status["available_lampmd"][value]}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["active_lampmd"] = value
-
-    async def get_available_color_temperature(self):
+    # -- Color temperature --
+    async def get_available_color_temperature(self) -> dict[str, int]:
         return self.status["available_colortmp"]
 
-    async def get_active_color_temperature(self):
+    async def get_active_color_temperature(self) -> str | None:
         return self.status["active_colortmp"]
 
-    async def set_active_color_temperature(self, value: str):
-        if self.status["active_colortmp"] == value:
-            return
+    async def set_active_color_temperature(self, value: str) -> None:
+        await self._set_choice("colortmp", value)
 
-        if value not in self.status["available_colortmp"]:
-            return
-
-        command = {"colortmp": self.status["available_colortmp"][value]}
-        await self._make_request("post", "/tgi/control.tgi", command)
-
-    async def get_available_logo(self):
+    # -- Logo --
+    async def get_available_logo(self) -> dict[str, int]:
         return self.status["available_logo"]
 
-    async def get_active_logo(self):
+    async def get_active_logo(self) -> str | None:
         return self.status["active_logo"]
 
-    async def set_active_logo(self, value: str):
-        if self.status["active_logo"] == value:
-            return
+    async def set_active_logo(self, value: str) -> None:
+        await self._set_choice("logo", value)
 
-        if value not in self.status["available_logo"]:
-            return
-
-        command = {"logo": self.status["available_logo"][value]}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["active_logo"] = value
-
-    async def get_available_power_modes(self):
+    # -- Power mode --
+    async def get_available_power_modes(self) -> dict[str, int]:
         return self.status["available_pwmode"]
 
-    async def get_active_power_mode(self):
+    async def get_active_power_mode(self) -> str | None:
         return self.status["active_pwmode"]
 
-    async def set_active_power_mode(self, value: str):
-        if self.status["active_pwmode"] == value:
-            return
+    async def set_active_power_mode(self, value: str) -> None:
+        await self._set_choice("pwmode", value)
 
-        if value not in self.status["available_pwmode"]:
-            return
-
-        command = {"pwmode": self.status["available_pwmode"][value]}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["pwmode"] = value
-
-    async def get_info_hide(self):
+    # -- Toggles --
+    async def get_info_hide(self) -> bool | None:
         return self.status["infohide"]
 
-    async def set_info_hide(self, value: bool):
-        if self.status["infohide"] == value:
-            return
+    async def set_info_hide(self, value: bool) -> None:
+        await self._toggle("infohide", value)
 
-        command = {"infohide": "Information Hide"}
-
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["infohide"] = value
-
-    async def get_always_on(self):
+    async def get_always_on(self) -> bool | None:
         return self.status["alwayson"]
 
-    async def set_always_on(self, value: bool):
-        if self.status["alwayson"] == value:
-            return
+    async def set_always_on(self, value: bool) -> None:
+        await self._toggle("alwayson", value)
 
-        command = {"alwayson": "Always On"}
-
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["alwayson"] = value
-
-    async def resync(self):
-        command = {"resync": "Resync"}
-        await self._make_request("post", "/tgi/control.tgi", command)
-
-    async def get_zoom(self):
-        return self.status["zoom"]
-
-    async def set_zoom(self, value: int):
-        command = {"zoom": value}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["zoom"] = value
-
-    async def get_horizontal_shift(self):
-        return self.status["hpos"]
-
-    async def set_horizontal_shift(self, value: int):
-        command = {"hpos": value}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["hpos"] = value
-
-    async def get_vertical_shift(self):
-        return self.status["vpos"]
-
-    async def set_vertical_shift(self, value: int):
-        command = {"vpos": value}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["vpos"] = value
-
-    async def get_auto_power_off(self):
-        return self.status["autopw"]
-
-    async def set_auto_power_off(self, value: int):
-        command = {"autopw": value}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["autopw"] = value
-
-    async def get_sleep_timer(self) -> int:
-        return self.status["sleep"]
-
-    async def set_sleep_timer(self, value: int):
-        command = {"sleep": value}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["sleep"] = value
-
-    async def get_projector_id(self):
-        return self.status["projid"]
-
-    async def set_projector_id(self, value: int):
-        command = {"projid": value}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["projid"] = value
-
-    async def get_brightness(self):
-        return self.status["bright"]
-
-    async def set_brightness(self, value: int):
-        command = {"bright": value}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["bright"] = value
-
-    async def get_contrast(self):
-        return self.status["contrast"]
-
-    async def set_contrast(self, value: int):
-        command = {"contrast": value}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["contrast"] = value
-
-    async def get_sharpness(self):
-        return self.status["Sharp"]
-
-    async def set_sharpness(self, value: int):
-        command = {"Sharp": value}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["Sharp"] = value
-
-    async def get_phase(self):
-        return self.status["Phase"]
-
-    async def set_phase(self, value: int):
-        command = {"Phase": value}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["Phase"] = value
-
-    async def get_brilliant_color(self):
-        return self.status["brill"]
-
-    async def set_brilliant_color(self, value: int):
-        command = {"brill": value}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["brill"] = value
-
-    async def get_freeze(self):
+    async def get_freeze(self) -> bool | None:
         return self.status["freeze"]
 
-    async def set_freeze(self, value: bool):
-        if self.status["freeze"] == value:
-            return
+    async def set_freeze(self, value: bool) -> None:
+        await self._toggle("freeze", value)
 
-        command = {"freeze": "Freeze"}
-
-        await self._make_request("post", "/tgi/control.tgi", command)
-
-        self.status["freeze"] = value
-
-    async def get_av_mute(self):
+    async def get_av_mute(self) -> bool | None:
         return self.status["avmute"]
 
-    async def set_av_mute(self, value: bool):
-        if self.status["avmute"] == value:
-            return
-        command = {"avmute": "AV Mute"}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["avmute"] = value
+    async def set_av_mute(self, value: bool) -> None:
+        await self._toggle("avmute", value)
 
-    async def get_high_altitude(self):
+    async def get_high_altitude(self) -> bool | None:
         return self.status["altitude"]
 
-    async def set_high_altitude(self, value: bool):
-        if self.status["altitude"] == value:
-            return
-        command = {"altitude": "High Altitude"}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["altitude"] = value
+    async def set_high_altitude(self, value: bool) -> None:
+        await self._toggle("altitude", value)
 
-    async def get_keypad_lock(self):
+    async def get_keypad_lock(self) -> bool | None:
         return self.status["keypad"]
 
-    async def set_keypad_lock(self, value: bool):
-        if self.status["keypad"] == value:
-            return
-        command = {"keypad": "Keypad Lock"}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["keypad"] = value
+    async def set_keypad_lock(self, value: bool) -> None:
+        await self._toggle("keypad", value)
 
-    async def get_display_mode_lock(self):
+    async def get_display_mode_lock(self) -> bool | None:
         return self.status["dismdlocked"]
 
-    async def set_display_mode_lock(self, value: bool):
-        if self.status["dismdlocked"] == value:
-            return
-        command = {"dismdlocked": "Display Mode Lock"}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["dismdlocked"] = value
+    async def set_display_mode_lock(self, value: bool) -> None:
+        await self._toggle("dismdlocked", value)
 
-    async def get_direct_power_on(self):
+    async def get_direct_power_on(self) -> bool | None:
         return self.status["directpwon"]
 
-    async def set_direct_power_on(self, value: bool):
-        if self.status["directpwon"] == value:
-            return
-        command = {"directpwon": "Direct Power On"}
-        await self._make_request("post", "/tgi/control.tgi", command)
-        self.status["directpwon"] = value
+    async def set_direct_power_on(self, value: bool) -> None:
+        await self._toggle("directpwon", value)
 
-    async def reset(self):
-        command = {"reset": "Reset"}
-        await self._make_request("post", "/tgi/control.tgi", command)
+    # -- Numeric values --
+    async def get_zoom(self) -> int | None:
+        return self.status["zoom"]
 
-    async def get_power(self):
+    async def set_zoom(self, value: int) -> None:
+        await self._set_value("zoom", value)
+
+    async def get_horizontal_shift(self) -> int | None:
+        return self.status["hpos"]
+
+    async def set_horizontal_shift(self, value: int) -> None:
+        await self._set_value("hpos", value)
+
+    async def get_vertical_shift(self) -> int | None:
+        return self.status["vpos"]
+
+    async def set_vertical_shift(self, value: int) -> None:
+        await self._set_value("vpos", value)
+
+    async def get_auto_power_off(self) -> int | None:
+        return self.status["autopw"]
+
+    async def set_auto_power_off(self, value: int) -> None:
+        await self._set_value("autopw", value)
+
+    async def get_sleep_timer(self) -> int | None:
+        return self.status["sleep"]
+
+    async def set_sleep_timer(self, value: int) -> None:
+        await self._set_value("sleep", value)
+
+    async def get_projector_id(self) -> int | None:
+        return self.status["projid"]
+
+    async def set_projector_id(self, value: int) -> None:
+        await self._set_value("projid", value)
+
+    async def get_brightness(self) -> int | None:
+        return self.status["bright"]
+
+    async def set_brightness(self, value: int) -> None:
+        await self._set_value("bright", value)
+
+    async def get_contrast(self) -> int | None:
+        return self.status["contrast"]
+
+    async def set_contrast(self, value: int) -> None:
+        await self._set_value("contrast", value)
+
+    async def get_sharpness(self) -> int | None:
+        return self.status["Sharp"]
+
+    async def set_sharpness(self, value: int) -> None:
+        await self._set_value("Sharp", value)
+
+    async def get_phase(self) -> int | None:
+        return self.status["Phase"]
+
+    async def set_phase(self, value: int) -> None:
+        await self._set_value("Phase", value)
+
+    async def get_brilliant_color(self) -> int | None:
+        return self.status["brill"]
+
+    async def set_brilliant_color(self, value: int) -> None:
+        await self._set_value("brill", value)
+
+    # -- Commands --
+    async def resync(self) -> None:
+        await self._make_request("POST", _CONTROL_PATH, {"resync": "Resync"})
+
+    async def reset(self) -> None:
+        await self._make_request("POST", _CONTROL_PATH, {"reset": "Reset"})
+
+    async def get_power(self) -> bool | None:
         return self.status["power"]
 
-    async def turn_on(self):
-        command = {"btn_powon": "Power On"}
-        await self._make_request("post", "/tgi/control.tgi", command)
+    async def turn_on(self) -> None:
+        await self._make_request("POST", _CONTROL_PATH, {"btn_powon": "Power On"})
         self.status["power"] = True
 
-    async def turn_off(self):
-        command = {"btn_powoff": "Power Off"}
-        await self._make_request("post", "/tgi/control.tgi", command)
+    async def turn_off(self) -> None:
+        await self._make_request("POST", _CONTROL_PATH, {"btn_powoff": "Power Off"})
         self.status["power"] = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ description = ""
 authors = ["Sebastian Lübke <luebke@gonicus.de>"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 httpx = "^0.27.0"
-bs4 = "^0.0.2"
+beautifulsoup4 = "^4.12.0"
 
 [tool.poetry.dev-dependencies]
 autoflake = "^2.0.0"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 set -x
-isort --recursive --force-single-line-imports --apply asyncoptoma
+isort --force-single-line-imports asyncoptoma
 autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place asyncoptoma
 black asyncoptoma
-isort --recursive --apply asyncoptoma
+isort asyncoptoma


### PR DESCRIPTION
- Fix Sharp/Phase tuple (was silently concatenated to "SharpPhase")
- Fix crash when #pwr input is missing from control page
- Fix set_active_color_temperature not updating active status
- Fix set_active_power_mode writing to wrong status key
- Fix inconsistent return from login() (now always bool)
- Fix case-sensitive HTTP method passed to httpx
- Replace deprecated bs4 package with beautifulsoup4
- Bump minimum Python to 3.9 (3.8 EOL)
- Collapse repeated setter/getter bodies into _set_choice/_set_value/_toggle
- Add async context manager and close() for proper client cleanup
- Add type hints and logging
- Drop deprecated isort --recursive/--apply flags in format.sh
- Fix README pip install typo